### PR TITLE
Fix: Scrollable.of throws on flutter master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0-dev.0
+### Fixed
+- Scrollable breaking change
+
 ## 2.0.0
 ### Added
 - Null safety

--- a/lib/src/widgets/gap.dart
+++ b/lib/src/widgets/gap.dart
@@ -71,7 +71,7 @@ class Gap extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ScrollableState? scrollableState = Scrollable.of(context);
+    final ScrollableState? scrollableState = Scrollable.maybeOf(context);
     final AxisDirection? axisDirection = scrollableState?.axisDirection;
     final Axis? fallbackDirection =
         axisDirection == null ? null : axisDirectionToAxis(axisDirection);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gap
 description: Flutter widgets for easily adding gaps inside Flex widgets such as Columns and Rows or scrolling views.
-version: 2.0.0
+version: 2.1.0-dev.0
 homepage: https://github.com/letsar/gap
 
 environment:


### PR DESCRIPTION
`Scrollable` now throws if you do `Scrollable.of`. Switched this to `Scrollable.maybeOf()`

Since it is not widely available in flutter, I set this up for a dev release.