### PR TITLE
add gap extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ return CustomScrollView(
 );
 ```
 
+### List<Widget> Extension
+
+You can also space a list of Widgets using the gap extension
+
+```dart
+return Row(
+  children: [
+    Icon(Icons.abc),
+    Icon(Icons.air),
+    Icon(Icons.add),
+  ].gap(10),
+);
+```
+
 ## Changelog
 
 Please see the [Changelog](https://github.com/letsar/gap/blob/master/CHANGELOG.md) page to know what's recently changed.

--- a/lib/gap.dart
+++ b/lib/gap.dart
@@ -1,4 +1,5 @@
 library gap;
 
+export 'package:gap/src/extensions.dart';
 export 'package:gap/src/widgets/gap.dart';
 export 'package:gap/src/widgets/sliver_gap.dart';

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'widgets/gap.dart';
+
+extension GapPackageListExtension<T extends Widget> on List<T> {
+  List<Widget> gap(double mainAxisExtent) {
+    return _gap(mainAxisExtent).toList();
+  }
+
+  Iterable<Widget> _gap(double mainAxisExtent) sync* {
+    final maxIndex = length - 1;
+    for (var i = 0; i <= maxIndex; i++) {
+      yield elementAt(i);
+      if (i != maxIndex) {
+        yield Gap(mainAxisExtent);
+      }
+    }
+  }
+}

--- a/test/gap_test.dart
+++ b/test/gap_test.dart
@@ -176,4 +176,24 @@ void main() {
       ),
     );
   });
+
+  testWidgets('gap extension size in a Row', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          textDirection: TextDirection.ltr,
+          children: <Widget>[
+            const SizedBox.square(dimension: 10),
+            const SizedBox.square(dimension: 10),
+            const SizedBox.square(dimension: 10),
+          ].gap(10),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(Row));
+    expect(box.size.width, 50);
+    expect(box.size.height, 10);
+  });
 }


### PR DESCRIPTION
This adds a gap extension to make it easier to evenly space Rows and Columns

```dart
return Row(
  children: [
    Icon(Icons.abc),
    Icon(Icons.air),
    Icon(Icons.add),
  ].gap(10),
);
```