### PR TITLE
Add `fit` and `flex` controls to `MaxGap` and refine gap layout behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ It's useful when you want to have a gap that shrinks to avoid an overflow otherw
 
 ### Other parameters
 
-By default a `Gap` will have no extent in the opposite direction of the `Flex` parent.
+By default a `Gap` treats the opposite direction extent as `0` before constraints are applied.
 If you want the `Gap` to have a color, you'll have to set the `color` and the `crossAxisExtent` parameters.
-You can also use the `Gap.expand` constructor to expand the `Gap` in the opposite direction of the `Flex` parent.
+You can also use the `Gap.expand` constructor to expand the `Gap` in the opposite direction of the parent.
 
 ### SliverGap
 
@@ -70,4 +70,3 @@ Feel free to contribute to this project.
 
 If you find a bug or want a feature, but don't know how to fix/implement it, please fill an [issue](https://github.com/letsar/gap/issues).  
 If you fixed a bug or implemented a feature, please send a [pull request](https://github.com/letsar/gap/pulls).
-

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The `Gap` widget also works inside `Scrollable` widgets such as `ListViews`. In 
 This package also comes with a `MaxGap` widget.
 The `MaxGap` widget will try to fill the available space in a `Column` or a `Row` with the specified size. If the available space
 is lesser than the specified size, the `MaxGap` widget will only take the available space.
+It also accepts an optional `flex` parameter if you need to control how multiple `MaxGap`s divide the available space.
 
 It's useful when you want to have a gap that shrinks to avoid an overflow otherwise.
 

--- a/lib/src/rendering/gap.dart
+++ b/lib/src/rendering/gap.dart
@@ -3,13 +3,15 @@ import 'package:flutter/rendering.dart';
 class RenderGap extends RenderBox {
   RenderGap({
     required double mainAxisExtent,
-    double? crossAxisExtent,
+    double crossAxisExtent = 0,
     Axis? fallbackDirection,
     Color? color,
   })  : _mainAxisExtent = mainAxisExtent,
         _crossAxisExtent = crossAxisExtent,
         _color = color,
         _fallbackDirection = fallbackDirection;
+
+  final Paint _paint = Paint();
 
   double get mainAxisExtent => _mainAxisExtent;
   double _mainAxisExtent;
@@ -20,9 +22,9 @@ class RenderGap extends RenderBox {
     }
   }
 
-  double? get crossAxisExtent => _crossAxisExtent;
-  double? _crossAxisExtent;
-  set crossAxisExtent(double? value) {
+  double get crossAxisExtent => _crossAxisExtent;
+  double _crossAxisExtent;
+  set crossAxisExtent(double value) {
     if (_crossAxisExtent != value) {
       _crossAxisExtent = value;
       markNeedsLayout();
@@ -38,13 +40,12 @@ class RenderGap extends RenderBox {
     }
   }
 
-  Axis? get _direction {
+  Axis? get _resolvedDirection {
     final parentNode = parent;
     if (parentNode is RenderFlex) {
       return parentNode.direction;
-    } else {
-      return fallbackDirection;
     }
+    return fallbackDirection;
   }
 
   Color? get color => _color;
@@ -61,7 +62,7 @@ class RenderGap extends RenderBox {
     return _computeIntrinsicExtent(
       Axis.horizontal,
       () => super.computeMinIntrinsicWidth(height),
-    )!;
+    );
   }
 
   @override
@@ -69,7 +70,7 @@ class RenderGap extends RenderBox {
     return _computeIntrinsicExtent(
       Axis.horizontal,
       () => super.computeMaxIntrinsicWidth(height),
-    )!;
+    );
   }
 
   @override
@@ -77,7 +78,7 @@ class RenderGap extends RenderBox {
     return _computeIntrinsicExtent(
       Axis.vertical,
       () => super.computeMinIntrinsicHeight(width),
-    )!;
+    );
   }
 
   @override
@@ -85,38 +86,38 @@ class RenderGap extends RenderBox {
     return _computeIntrinsicExtent(
       Axis.vertical,
       () => super.computeMaxIntrinsicHeight(width),
-    )!;
+    );
   }
 
-  double? _computeIntrinsicExtent(Axis axis, double Function() compute) {
-    final Axis? direction = _direction;
+  double _computeIntrinsicExtent(Axis axis, double Function() compute) {
+    final Axis? direction = _resolvedDirection;
     if (direction == axis) {
-      return _mainAxisExtent;
-    } else {
-      if (_crossAxisExtent!.isFinite) {
-        return _crossAxisExtent;
-      } else {
-        return compute();
-      }
+      return mainAxisExtent;
     }
+    if (crossAxisExtent.isFinite) {
+      return crossAxisExtent;
+    }
+    return compute();
+  }
+
+  Size _sizeForDirection(Axis direction) {
+    if (direction == Axis.horizontal) {
+      return Size(mainAxisExtent, crossAxisExtent);
+    }
+    return Size(crossAxisExtent, mainAxisExtent);
   }
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    final Axis? direction = _direction;
-
-    if (direction != null) {
-      if (direction == Axis.horizontal) {
-        return constraints.constrain(Size(mainAxisExtent, crossAxisExtent!));
-      } else {
-        return constraints.constrain(Size(crossAxisExtent!, mainAxisExtent));
-      }
-    } else {
+    final Axis? direction = _resolvedDirection;
+    if (direction == null) {
       throw FlutterError(
         'A Gap widget must be placed directly inside a Flex widget '
         'or its fallbackDirection must not be null',
       );
     }
+
+    return constraints.constrain(_sizeForDirection(direction));
   }
 
   @override
@@ -126,10 +127,12 @@ class RenderGap extends RenderBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (color != null) {
-      final Paint paint = Paint()..color = color!;
-      context.canvas.drawRect(offset & size, paint);
+    final Color? color = this.color;
+    if (color == null) {
+      return;
     }
+    _paint.color = color;
+    context.canvas.drawRect(offset & size, _paint);
   }
 
   @override

--- a/lib/src/rendering/sliver_gap.dart
+++ b/lib/src/rendering/sliver_gap.dart
@@ -7,6 +7,8 @@ class RenderSliverGap extends RenderSliver {
   })  : _mainAxisExtent = mainAxisExtent,
         _color = color;
 
+  final Paint _paint = Paint();
+
   double get mainAxisExtent => _mainAxisExtent;
   double _mainAxisExtent;
   set mainAxisExtent(double value) {
@@ -53,16 +55,18 @@ class RenderSliverGap extends RenderSliver {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (color != null) {
-      final Paint paint = Paint()..color = color!;
-      final Size size = constraints
-          .asBoxConstraints(
-            minExtent: geometry!.paintExtent,
-            maxExtent: geometry!.paintExtent,
-          )
-          .constrain(Size.zero);
-      context.canvas.drawRect(offset & size, paint);
+    final Color? color = this.color;
+    if (color == null) {
+      return;
     }
+    final Size size = constraints
+        .asBoxConstraints(
+          minExtent: geometry!.paintExtent,
+          maxExtent: geometry!.paintExtent,
+        )
+        .constrain(Size.zero);
+    _paint.color = color;
+    context.canvas.drawRect(offset & size, _paint);
   }
 
   @override

--- a/lib/src/widgets/gap.dart
+++ b/lib/src/widgets/gap.dart
@@ -61,9 +61,10 @@ class Gap extends StatelessWidget {
   /// - If the parent is a [Column] this is the width of this widget.
   /// - If the parent is a [Row] this is the height of this widget.
   ///
-  /// Must be positive or null. If it's null (the default) the cross axis extent
-  /// will be the same as the constraints of the parent in the opposite
-  /// direction.
+  /// Must be positive or null.
+  ///
+  /// If it's null (the default), it is treated as `0` before constraints are
+  /// applied. Use [Gap.expand] to expand in the cross axis.
   final double? crossAxisExtent;
 
   /// The color used to fill the gap.
@@ -107,6 +108,7 @@ class MaxGap extends StatelessWidget {
     Key? key,
     this.crossAxisExtent,
     this.color,
+    this.fit = FlexFit.loose,
   }) : super(key: key);
 
   /// Creates a widget that takes, at most, the specified [mainAxisExtent] of
@@ -119,11 +121,13 @@ class MaxGap extends StatelessWidget {
     double mainAxisExtent, {
     Key? key,
     Color? color,
+    FlexFit fit = FlexFit.loose,
   }) : this(
           mainAxisExtent,
           key: key,
           crossAxisExtent: double.infinity,
           color: color,
+          fit: fit,
         );
 
   /// The amount of space this widget takes in the direction of the parent.
@@ -140,17 +144,24 @@ class MaxGap extends StatelessWidget {
   /// If the parent is a [Column] this is the width of this widget.
   /// If the parent is a [Row] this is the height of this widget.
   ///
-  /// Must be positive or null. If it's null (the default) the cross axis extent
-  /// will be the same as the constraints of the parent in the opposite
-  /// direction.
+  /// Must be positive or null.
+  ///
+  /// If it's null (the default), it is treated as `0` before constraints are
+  /// applied. Use [MaxGap.expand] to expand in the cross axis.
   final double? crossAxisExtent;
 
   /// The color used to fill the gap.
   final Color? color;
 
+  /// How a flexible gap is inscribed into the available space.
+  ///
+  /// Defaults to [FlexFit.loose], which preserves the existing behavior.
+  final FlexFit fit;
+
   @override
   Widget build(BuildContext context) {
     return Flexible(
+      fit: fit,
       child: _RawGap(
         mainAxisExtent,
         crossAxisExtent: crossAxisExtent,

--- a/lib/src/widgets/gap.dart
+++ b/lib/src/widgets/gap.dart
@@ -108,6 +108,7 @@ class MaxGap extends StatelessWidget {
     Key? key,
     this.crossAxisExtent,
     this.color,
+    this.flex = 1,
     this.fit = FlexFit.loose,
   }) : super(key: key);
 
@@ -121,12 +122,14 @@ class MaxGap extends StatelessWidget {
     double mainAxisExtent, {
     Key? key,
     Color? color,
+    int flex = 1,
     FlexFit fit = FlexFit.loose,
   }) : this(
           mainAxisExtent,
           key: key,
           crossAxisExtent: double.infinity,
           color: color,
+          flex: flex,
           fit: fit,
         );
 
@@ -153,6 +156,11 @@ class MaxGap extends StatelessWidget {
   /// The color used to fill the gap.
   final Color? color;
 
+  /// The flex factor used by the surrounding [Flexible].
+  ///
+  /// Defaults to `1`, which preserves the existing behavior.
+  final int flex;
+
   /// How a flexible gap is inscribed into the available space.
   ///
   /// Defaults to [FlexFit.loose], which preserves the existing behavior.
@@ -161,6 +169,7 @@ class MaxGap extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Flexible(
+      flex: flex,
       fit: fit,
       child: _RawGap(
         mainAxisExtent,

--- a/test/gap_test.dart
+++ b/test/gap_test.dart
@@ -18,17 +18,20 @@ void main() {
     expect(c.mainAxisExtent, 0);
     expect(c.crossAxisExtent, null);
     expect(c.color, null);
+    expect(c.flex, 1);
     expect(c.fit, FlexFit.loose);
 
     const MaxGap d = MaxGap(
       10,
       crossAxisExtent: 20,
       color: Colors.red,
+      flex: 2,
       fit: FlexFit.tight,
     );
     expect(d.mainAxisExtent, 10);
     expect(d.crossAxisExtent, 20);
     expect(d.color, Colors.red);
+    expect(d.flex, 2);
     expect(d.fit, FlexFit.tight);
 
     const Gap e = Gap.expand(10, color: Colors.red);
@@ -39,11 +42,13 @@ void main() {
     const MaxGap f = MaxGap.expand(
       10,
       color: Colors.red,
+      flex: 2,
       fit: FlexFit.tight,
     );
     expect(f.mainAxisExtent, 10);
     expect(f.crossAxisExtent, double.infinity);
     expect(f.color, Colors.red);
+    expect(f.flex, 2);
     expect(f.fit, FlexFit.tight);
   });
 
@@ -232,6 +237,72 @@ void main() {
 
     final RenderBox box = tester.renderObject(find.byType(MaxGap));
     expect(box.size.width, 200);
+    expect(box.size.height, 20);
+  });
+
+  testWidgets('MaxGap forwards flex to Flexible',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Row(
+        textDirection: TextDirection.ltr,
+        children: <Widget>[
+          MaxGap(100, flex: 3),
+        ],
+      ),
+    );
+
+    final Flexible flexible = tester.widget(find.byType(Flexible));
+    expect(flexible.flex, 3);
+    expect(flexible.fit, FlexFit.loose);
+  });
+
+  testWidgets('MaxGap flex affects space distribution in a Row',
+      (WidgetTester tester) async {
+    const Key firstKey = ValueKey<String>('first-gap');
+    const Key secondKey = ValueKey<String>('second-gap');
+
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          width: 180,
+          child: Row(
+            textDirection: TextDirection.ltr,
+            children: <Widget>[
+              MaxGap(200, key: firstKey, crossAxisExtent: 20),
+              MaxGap(200, key: secondKey, crossAxisExtent: 20, flex: 2),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox firstBox = tester.renderObject(find.byKey(firstKey));
+    final RenderBox secondBox = tester.renderObject(find.byKey(secondKey));
+
+    expect(firstBox.size.width, 60);
+    expect(secondBox.size.width, 120);
+    expect(firstBox.size.height, 20);
+    expect(secondBox.size.height, 20);
+  });
+
+  testWidgets('MaxGap remains constrained when custom flex is used',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          width: 90,
+          child: Row(
+            textDirection: TextDirection.ltr,
+            children: <Widget>[
+              MaxGap(100, crossAxisExtent: 20, flex: 3),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(MaxGap));
+    expect(box.size.width, 90);
     expect(box.size.height, 20);
   });
 

--- a/test/gap_test.dart
+++ b/test/gap_test.dart
@@ -18,21 +18,33 @@ void main() {
     expect(c.mainAxisExtent, 0);
     expect(c.crossAxisExtent, null);
     expect(c.color, null);
+    expect(c.fit, FlexFit.loose);
 
-    const MaxGap d = MaxGap(10, crossAxisExtent: 20, color: Colors.red);
+    const MaxGap d = MaxGap(
+      10,
+      crossAxisExtent: 20,
+      color: Colors.red,
+      fit: FlexFit.tight,
+    );
     expect(d.mainAxisExtent, 10);
     expect(d.crossAxisExtent, 20);
     expect(d.color, Colors.red);
+    expect(d.fit, FlexFit.tight);
 
     const Gap e = Gap.expand(10, color: Colors.red);
     expect(e.mainAxisExtent, 10);
     expect(e.crossAxisExtent, double.infinity);
     expect(e.color, Colors.red);
 
-    const MaxGap f = MaxGap.expand(10, color: Colors.red);
+    const MaxGap f = MaxGap.expand(
+      10,
+      color: Colors.red,
+      fit: FlexFit.tight,
+    );
     expect(f.mainAxisExtent, 10);
     expect(f.crossAxisExtent, double.infinity);
     expect(f.color, Colors.red);
+    expect(f.fit, FlexFit.tight);
   });
 
   testWidgets('Gap size in a Row', (WidgetTester tester) async {
@@ -83,6 +95,53 @@ void main() {
     final RenderBox box = tester.renderObject(find.byType(Gap));
     expect(box.size.height, 100);
     expect(box.size.width, 200);
+  });
+
+  testWidgets('Gap defaults to zero cross-axis extent in a Row',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Row(
+        textDirection: TextDirection.ltr,
+        children: <Widget>[
+          Gap(100),
+        ],
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(Gap));
+    expect(box.size.width, 100);
+    expect(box.size.height, 0);
+  });
+
+  testWidgets('Gap paints its color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Row(
+        textDirection: TextDirection.ltr,
+        children: <Widget>[
+          Gap(40, crossAxisExtent: 20, color: Colors.red),
+        ],
+      ),
+    );
+
+    expect(find.byType(Gap), paints..rect(color: Colors.red));
+  });
+
+  testWidgets('Gap intrinsic sizes use zero cross-axis extent by default',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Column(
+        textDirection: TextDirection.ltr,
+        children: <Widget>[
+          Gap(40),
+        ],
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(Gap));
+    expect(box.getMinIntrinsicWidth(double.infinity), 0);
+    expect(box.getMaxIntrinsicWidth(double.infinity), 0);
+    expect(box.getMinIntrinsicHeight(double.infinity), 40);
+    expect(box.getMaxIntrinsicHeight(double.infinity), 40);
   });
 
   testWidgets('MaxGap size in a Row', (WidgetTester tester) async {
@@ -154,6 +213,26 @@ void main() {
     final RenderBox box = tester.renderObject(find.byType(MaxGap));
     expect(box.size.height, 50);
     expect(box.size.width, 20);
+  });
+
+  testWidgets('MaxGap fit can be made tight', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          width: 200,
+          child: Row(
+            textDirection: TextDirection.ltr,
+            children: <Widget>[
+              MaxGap(100, crossAxisExtent: 20, fit: FlexFit.tight),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(MaxGap));
+    expect(box.size.width, 200);
+    expect(box.size.height, 20);
   });
 
   testWidgets(

--- a/test/scrollable_gap_test.dart
+++ b/test/scrollable_gap_test.dart
@@ -27,6 +27,30 @@ void main() {
     expect(box.size.height, 200);
   });
 
+  testWidgets('Gap with crossAxisExtent inside horizontal ListView',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            height: 200,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: const <Widget>[
+                Gap(100, crossAxisExtent: 20),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(Gap));
+    expect(box.size.width, 100);
+    expect(box.size.height, 200);
+  });
+
   testWidgets('Gap inside vertical ListView', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(

--- a/test/sliver_gap_test.dart
+++ b/test/sliver_gap_test.dart
@@ -48,4 +48,41 @@ void main() {
     expect(sliver.geometry!.layoutExtent, 100);
     expect(sliver.geometry!.paintExtent, 100);
   });
+
+  testWidgets('SliverGap paints its color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverGap(40, color: Colors.red),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.byType(SliverGap), paints..rect(color: Colors.red));
+  });
+
+  testWidgets('SliverGap paintExtent shrinks with scroll offset',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 75);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          slivers: const <Widget>[
+            SliverGap(100, color: Colors.red),
+          ],
+        ),
+      ),
+    );
+
+    final RenderSliver sliver = tester.renderObject(find.byType(SliverGap));
+    expect(sliver.geometry!.scrollExtent, 100);
+    expect(sliver.geometry!.paintExtent, 25);
+  });
 }


### PR DESCRIPTION
# Improve gap cross-axis handling and add `fit`/`flex` controls to `MaxGap`

## Summary

This PR improves `Gap`/`MaxGap` layout behavior and expands `MaxGap`'s Flex configurability without breaking existing usage.

It includes the earlier refactor around `crossAxisExtent` and `MaxGap.fit`, plus the follow-up change from issue #17 to add a configurable `flex` parameter to `MaxGap`.

## Changes

- Treat `crossAxisExtent` as `0` by default before constraints are applied.
- Add `fit` to `MaxGap` so it can opt into `FlexFit.tight`.
- Add `flex` to `MaxGap`, defaulting to `1` to preserve current behavior.
- Forward both `fit` and `flex` to the internal `Flexible`.
- Keep existing call sites like `MaxGap(24)` source-compatible.
- Reuse `Paint` objects in `RenderGap` and `RenderSliverGap`.
- Update docs and tests to reflect the current behavior.

## Behavior

- No breaking API changes.
- Existing `MaxGap` behavior remains unchanged by default.
- `MaxGap` now supports custom Flex distribution when multiple gaps are used together.
- `Gap` and `MaxGap` continue to shrink correctly when constrained.

## Tests

Added and updated tests covering:

- default constructor behavior
- zero cross-axis extent behavior
- painting behavior for `Gap` and `SliverGap`
- `MaxGap.fit`
- `MaxGap.flex` forwarding
- space distribution between multiple `MaxGap`s with different `flex` values
- constrained `MaxGap` behavior
- scrollable and sliver layout cases
